### PR TITLE
Only redraw drilldown charts when necessary, and rearranged elements

### DIFF
--- a/state-level.css
+++ b/state-level.css
@@ -1,5 +1,10 @@
+#dashboard_wrapper {
+  width: 1100px;
+  margin: 20px auto;
+}
+
 #map_wrapper {
-  width: 800px;
+  width: 500px;
   margin: auto;
 }
 
@@ -8,14 +13,14 @@
   width: 500px; 
   /*margin: 0px auto;*/
   overflow: hidden;
-  margin-left: 300;
+  margin: auto;
 }
 
 .map-instructions {
-  margin: 70px auto;
+  margin: 80px 0px 0px 40px;
   font-family: "Lucida Grande", "Lucida Sans Unicode", sans-serif;
   color: #C14D00;
-  font-size: 16px;
+  font-size: 15px;
 }
 
 .drilldown.title {
@@ -37,15 +42,15 @@
 }
 
 .age-form {
-  float: left;
-  clear: left;
-  margin: 10px;
+
+  margin: auto;
   width: 300px;
+  display: block;
 }
 
 .select-age {
   width: 100%;
-  margin: 10px 5px auto;
+  margin: 10px auto 10px;
   font-size:16px; 
   display: inline-block;
   height: 22px;
@@ -53,12 +58,14 @@
 
 .table-notes {
   font-size: 11px;
+  width: 500px;
+  margin: auto 20px;
 }
 
 
 /*~~~~~~~~~~~~~ Year Slider ~~~~~~~~~~~~~~~~*/
 #year_slider {
-  margin: 20px 10px 10px 425px;
+  margin: 20px auto 10px auto;
   /*margin-left: 400px;*/
   -webkit-appearance: none;
   width: 300px;
@@ -70,23 +77,23 @@
 }
 
 #year_slider::-webkit-slider-thumb {
-    -webkit-appearance: none; /* Override default look */
-    appearance: none;
-    width: 25px; /* Set a specific slider handle width */
-    height: 25px; /* Slider handle height */
-    border-radius: 20%;
-    background: #4E7686; /* Green background */
-    cursor: pointer; /* Cursor on hover */
+  -webkit-appearance: none; /* Override default look */
+  appearance: none;
+  width: 25px; /* Set a specific slider handle width */
+  height: 25px; /* Slider handle height */
+  border-radius: 20%;
+  background: #4E7686; /* Green background */
+  cursor: pointer; /* Cursor on hover */
 }
 
 
 #year_slider::-moz-range-thumb {
-    appearance: none;
-    width: 25px; /* Set a specific slider handle width */
-    height: 25px; /* Slider handle height */
-    border-radius: 20%;
-    background: #4E7686; /* Green background */
-    cursor: pointer; /* Cursor on hover */
+  appearance: none;
+  width: 25px; /* Set a specific slider handle width */
+  height: 25px; /* Slider handle height */
+  border-radius: 20%;
+  background: #4E7686; /* Green background */
+  cursor: pointer; /* Cursor on hover */
 }
 
 #year_label {
@@ -97,7 +104,7 @@
   /*margin: 15px auto;*/
   position: fixed;
   left: 50%;
-  margin-left: 330px;
+  margin-left: 155px;
   margin-top: -29px;
 
 }

--- a/state-level.html
+++ b/state-level.html
@@ -1,46 +1,46 @@
-<div id="map_wrapper">
+<div id="dashboard_wrapper">
   <div id="drilldown_title" class="drilldown title"></div>
   <div id="age_group_chart" class="drilldown">
-    <h4 class="map-instructions">Click on a state to see age groups and change over time</h4>
+    <h4 class="map-instructions">Click on a state to see age groups<br>and change over time ==></h4>
   </div>
   <div id="time_series_chart" class="drilldown"></div>
-  <div id="state_migration_map"></div>
 
-  <form class="age-form">
-    <select id="select_age" class="select-age">
-      <option value="10" selected>All Ages</option>
-      <option value="11">Under 26</option>
-      <option value="12">26-34</option>
-      <option value="13">35-44</option>
-      <option value="14">45-54</option>
-      <option value="15">55-64</option>
-      <option value="16">65 and over</option>
-    </select>
-  </form>
-  
-  <!-- To show households (i.e. returns):
-      <option value="3" selected>All Ages</option>
-      <option value="4">Under 26</option>
-      <option value="5">26-34</option>
-      <option value="6">35-44</option>
-      <option value="7">45-54</option>
-      <option value="8">55-64</option>
-      <option value="9">65 and over</option>
--->
-  
-  <!-- "min" and "max" of slider represent columns of HI data in google sheet -->
-  <input id="year_slider" type="range" min=2012 max=2016 value=2016>
-  <p id= "year_label" class="hidden">2016</p>
+  <div id="map_wrapper">
+    <div id="state_migration_map"></div>
 
-  <br />
-  <p class="table-notes">
-    Notes: Data are measured using tax exemptions, which approximate individuals. 
-    <br/>
-    Source: JCHS tabulations of IRS, SOI Migration Data.
-  </p>
+    <input id="year_slider" type="range" min=2012 max=2016 value=2016>
+    <p id= "year_label" class="hidden">2016</p>
 
+    <form class="age-form">
+      <select id="select_age" class="select-age">
+        <option value="10" selected>All Ages</option>
+        <option value="11">Under 26</option>
+        <option value="12">26-34</option>
+        <option value="13">35-44</option>
+        <option value="14">45-54</option>
+        <option value="15">55-64</option>
+        <option value="16">65 and over</option>
+
+        <!-- To show households (i.e. returns):
+        <option value="3" selected>All Ages</option>
+        <option value="4">Under 26</option>
+        <option value="5">26-34</option>
+        <option value="6">35-44</option>
+        <option value="7">45-54</option>
+        <option value="8">55-64</option>
+        <option value="9">65 and over</option>
+        -->
+
+      </select>
+    </form>
+    <p class="table-notes">
+      Notes: Data are measured using tax exemptions, which approximate individuals. 
+      <br/>
+      Source: JCHS tabulations of IRS, SOI Migration Data.
+    </p>
+
+  </div>
 </div>
-
 
 <!-- jQuery (for additional interactive features) -->
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>

--- a/state-level.js
+++ b/state-level.js
@@ -55,7 +55,8 @@ function createMap() {
       chart: {
         //height: 600,
         //width: 800,
-        margin: [50, 5, 60, 5],
+        margin: [35, 0, 60, 0],
+        spacingTop: 0,
         borderWidth: 0,
         events: {
           load: function() {
@@ -113,8 +114,26 @@ function createMap() {
         }*/
       },
 
-      mapNavigation: {
-        enabled: true
+      mapNavigation: { 
+        enabled: true,
+        buttonOptions: {
+          align: 'right',
+          verticalAlign: 'bottom',
+          width: 8,
+          height: 13,
+          style: {
+            fontSize: '12px'
+          }
+        },
+        buttons: {
+          zoomIn: {
+            y: 35
+          },
+          zoomOut: {
+            y: 35,
+            x: -18
+          }
+        }
       },
 
       colorAxis: {
@@ -199,7 +218,7 @@ function createMap() {
 
       /*~~~~~~Exporting options~~~~~~*/
       exporting: {
-        enabled: true,
+        enabled: false,
         filename: "Highmaps test",
         menuItemDefinitions: {
           downloadFullData: {
@@ -235,7 +254,7 @@ function createMap() {
 
 $('#year_slider').on('change', function () {
   selected_year = $('#year_slider').val()
-  changeData()
+  changeData(false)
 })
 
 $('#select_age').on('change', function () {
@@ -245,10 +264,10 @@ $('#select_age').on('change', function () {
   } else {
     map.update({colorAxis: {min: -200000, max: 200000}})
   }
-  changeData()
+  changeData(true)
 })
 
-function changeData () {
+function changeData (changeLineChart) {
   var new_data = []
 
   ref_data
@@ -273,20 +292,30 @@ function changeData () {
 
     ref_data.forEach(function (el) {
       if (el[1] == GEOID) {
-        new_line_data.push( {y: el[selected_age_idx], x: el[0]} )
-
-        if (el[0] == selected_year) {
-          el.slice(11,17).map(x => new_chart_data.push(x))
-        } //end if
-
+        if (changeLineChart === true) {
+          new_line_data.push( {y: el[selected_age_idx], x: el[0]} )
+        } else {
+          if (el[0] == selected_year) {
+            el.slice(11,17).map(x => new_chart_data.push(x))
+          } //end if
+        }
       } //end if
     }) //end forEach
-    
-    timeSeriesChart.series[0].update({name: 'Net Flow' + '<br/><span style="font-size: 10px; font-weight: normal;">' + $('#select_age :selected').html() + '</span>'})
-    timeSeriesChart.series[0].setData(new_line_data)
-    ageGroupChart.series[0].setData(new_chart_data)
 
-    $('#drilldown_title').html(state_name + ', ' + selected_year)
+    if (changeLineChart === true) {
+      timeSeriesChart.series[0].update({label: {enabled: false}})
+      timeSeriesChart.series[0].update({
+        name: 'Net Flow' + '<br/><span style="font-size: 10px; font-weight: normal;">' + $('#select_age :selected').html() + '</span>', 
+        label: {enabled: true}
+      })
+      timeSeriesChart.series[0].setData(new_line_data)
+    
+    } else {
+      ageGroupChart.series[0].setData(new_chart_data)
+      $('#drilldown_title').html(state_name + ', ' + selected_year)
+
+    }
+
 
   }
 
@@ -428,7 +457,7 @@ function drilldownState (GEOID, state_name) {
 
   //add button to clear the selection
   if (!$('#clear_button').length) {
-    map.renderer.button('Clear<br />selection',430,300)
+    map.renderer.button('Clear<br />selection',440,255)
       .attr({
       padding: 3,
       id: 'clear_button'
@@ -440,7 +469,7 @@ function drilldownState (GEOID, state_name) {
 
       $('#clear_button').remove()
       $('#drilldown_title').html('')
-      $('#age_group_chart').append('<h4 class="map-instructions">Click on a state to see age groups and change over time</h4>')
+      $('#age_group_chart').append('<h4 class="map-instructions">Click on a state to see age groups<br>and change over time ==></h4>')
 
       timeSeriesChart.destroy()
       ageGroupChart.destroy()


### PR DESCRIPTION
Refactored code to only redraw charts when necessary (e.g., don't redraw time series when year slider changes). This avoids distracting redraws of identical data. 

Also rearranged some of the elements, including putting age group selector under year slider, moving map navigation to lower right, and removing export option (since it only applied to the map).

Closes #24 